### PR TITLE
Testing how PRs to Branches works :) 

### DIFF
--- a/CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.cc
+++ b/CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.cc
@@ -83,7 +83,7 @@ void HDF5ProductResolver::prefetchAsyncImpl(edm::WaitingTaskHolder iTask,
           CMS_SA_ALLOW try {
             edm::ESModuleCallingContext context(providerDescription(),
                                                 reinterpret_cast<std::uintptr_t>(this),
-                                                edm::ESModuleCallingContext::State::kRunning,
+                                                edm::ESModuleCallingContext::State::kPrefetching,
                                                 iParent);
             iRecord.activityRegistry()->preESModuleSignal_.emit(iRecord.key(), context);
             struct EndGuard {

--- a/DataFormats/CaloRecHit/BuildFile.xml
+++ b/DataFormats/CaloRecHit/BuildFile.xml
@@ -3,7 +3,9 @@
 <use name="DataFormats/DetId"/>
 <use name="FWCore/Utilities"/>
 <use name="rootmathcore"/>
+<use name="alpaka"/>
 <use name="eigen"/>
+<use name="xtd"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/CaloRecHit/BuildFile.xml
+++ b/DataFormats/CaloRecHit/BuildFile.xml
@@ -1,11 +1,15 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Math"/>
 <use name="DataFormats/DetId"/>
+<use name="DataFormats/Portable"/>
+<use name="DataFormats/SoATemplate"/>
 <use name="FWCore/Utilities"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<use name="rootcling"/>
 <use name="rootmathcore"/>
-<use name="alpaka"/>
 <use name="eigen"/>
 <use name="xtd"/>
+<flags ALPAKA_BACKENDS="!serial"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/CaloRecHit/interface/CaloClusterHostCollection.h
+++ b/DataFormats/CaloRecHit/interface/CaloClusterHostCollection.h
@@ -1,0 +1,15 @@
+
+#ifndef DataFormats_CaloRecHit_CaloClusterHostCollection_H
+#define DataFormats_CaloRecHit_CaloClusterHostCollection_H
+
+#include "DataFormats/CaloRecHit/interface/CaloClusterSoA.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include <alpaka/alpaka.hpp>
+
+namespace reco {
+
+  using CaloClusterHostCollection = PortableHostCollection<CaloClusterSoA>;
+
+}  // namespace reco
+
+#endif

--- a/DataFormats/CaloRecHit/interface/CaloClusterSoA.h
+++ b/DataFormats/CaloRecHit/interface/CaloClusterSoA.h
@@ -1,0 +1,70 @@
+
+#ifndef DataFormats_CaloRecHit_CaloClusterSoA_H
+#define DataFormats_CaloRecHit_CaloClusterSoA_H
+
+// Authors: Simone Balducci, Felice Pantaleo, Wahid Redjeb, Aurora Perego, Leonardo Beltrame
+
+#include "DataFormats/SoATemplate/interface/SoABlocks.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+#include "DataFormats/CaloRecHit/interface/CaloID.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include <xtd/xtd.h>
+
+namespace reco {
+
+  GENERATE_SOA_LAYOUT(CaloClusterSoAPosition,
+                      SOA_COLUMN(float, x),
+                      SOA_COLUMN(float, y),
+                      SOA_COLUMN(float, z),
+                      SOA_COLUMN(int, layer),
+                      SOA_COLUMN(int, cells))
+
+  GENERATE_SOA_LAYOUT(CaloClusterSoAEnergy,
+                      SOA_COLUMN(float, energy),
+                      SOA_COLUMN(float, correctedEnergy),
+                      SOA_COLUMN(float, correctedEnergyUncertainty))
+
+  GENERATE_SOA_LAYOUT(CaloClusterSoAIndexes,
+                      SOA_COLUMN(CaloID, caloID),
+                      SOA_COLUMN(CaloCluster::AlgoID, algoID),
+                      SOA_COLUMN(DetId, seedID),
+                      SOA_COLUMN(uint32_t, flags))
+
+  GENERATE_SOA_LAYOUT(CaloClusterSoATiming, SOA_COLUMN(float, time), SOA_COLUMN(float, timeError))
+
+  // clang-format off
+  GENERATE_SOA_BLOCKS(CaloClusterSoALayout,
+                      SOA_BLOCK(position, CaloClusterSoAPosition),
+                      SOA_BLOCK(energy, CaloClusterSoAEnergy),
+                      SOA_BLOCK(indexes, CaloClusterSoAIndexes),
+                      SOA_BLOCK(timing, CaloClusterSoATiming),
+                      SOA_CONST_VIEW_METHODS(
+                        SOA_HOST_DEVICE auto r(std::integral auto idx) const {
+                          const auto x = this->position()[idx].x();
+                          const auto y = this->position()[idx].y();
+                          return xtd::sqrt(x * x + y * y);
+                        }
+                        SOA_HOST_DEVICE auto phi(std::integral auto idx) const {
+                          const auto x = this->position()[idx].x();
+                          const auto y = this->position()[idx].y();
+                          return xtd::atan2(y, x);
+                        }
+                        SOA_HOST_DEVICE auto eta(std::integral auto idx) const {
+                          const auto x = this->position()[idx].x();
+                          const auto y = this->position()[idx].y();
+                          const auto z = this->position()[idx].z();
+                          const auto theta = xtd::atan(xtd::sqrt(x * x + y * y) / z);
+                          return -xtd::log(xtd::tan(theta / 2));
+                        }
+                      )
+  )
+  // clang-format on
+
+  using CaloClusterSoA = CaloClusterSoALayout<>;
+  using CaloClusterSoAView = CaloClusterSoA::View;
+  using CaloClusterSoAConstView = CaloClusterSoA::ConstView;
+
+}  // namespace reco
+
+#endif

--- a/DataFormats/CaloRecHit/interface/CaloClusterSoA.h
+++ b/DataFormats/CaloRecHit/interface/CaloClusterSoA.h
@@ -13,12 +13,19 @@
 
 namespace reco {
 
+  // clang-format off
   GENERATE_SOA_LAYOUT(CaloClusterSoAPosition,
                       SOA_COLUMN(float, x),
                       SOA_COLUMN(float, y),
                       SOA_COLUMN(float, z),
                       SOA_COLUMN(int, layer),
-                      SOA_COLUMN(int, cells))
+                      SOA_COLUMN(int, cells),
+                      SOA_CONST_ELEMENT_METHODS(
+                        SOA_HOST_DEVICE auto r() const { return xtd::sqrt(x() * x() + y() * y()); }
+                        SOA_HOST_DEVICE auto phi() const { return xtd::atan2(y(), x()); }
+                        SOA_HOST_DEVICE auto eta() const { return xtd::asinh(z() / r()); }
+                      ))
+  // clang-format on
 
   GENERATE_SOA_LAYOUT(CaloClusterSoAEnergy,
                       SOA_COLUMN(float, energy),
@@ -33,33 +40,11 @@ namespace reco {
 
   GENERATE_SOA_LAYOUT(CaloClusterSoATiming, SOA_COLUMN(float, time), SOA_COLUMN(float, timeError))
 
-  // clang-format off
   GENERATE_SOA_BLOCKS(CaloClusterSoALayout,
                       SOA_BLOCK(position, CaloClusterSoAPosition),
                       SOA_BLOCK(energy, CaloClusterSoAEnergy),
                       SOA_BLOCK(indexes, CaloClusterSoAIndexes),
-                      SOA_BLOCK(timing, CaloClusterSoATiming),
-                      SOA_CONST_VIEW_METHODS(
-                        SOA_HOST_DEVICE auto r(std::integral auto idx) const {
-                          const auto x = this->position()[idx].x();
-                          const auto y = this->position()[idx].y();
-                          return xtd::sqrt(x * x + y * y);
-                        }
-                        SOA_HOST_DEVICE auto phi(std::integral auto idx) const {
-                          const auto x = this->position()[idx].x();
-                          const auto y = this->position()[idx].y();
-                          return xtd::atan2(y, x);
-                        }
-                        SOA_HOST_DEVICE auto eta(std::integral auto idx) const {
-                          const auto x = this->position()[idx].x();
-                          const auto y = this->position()[idx].y();
-                          const auto z = this->position()[idx].z();
-                          const auto theta = xtd::atan(xtd::sqrt(x * x + y * y) / z);
-                          return -xtd::log(xtd::tan(theta / 2));
-                        }
-                      )
-  )
-  // clang-format on
+                      SOA_BLOCK(timing, CaloClusterSoATiming))
 
   using CaloClusterSoA = CaloClusterSoALayout<>;
   using CaloClusterSoAView = CaloClusterSoA::View;

--- a/DataFormats/CaloRecHit/interface/alpaka/CaloClusterDeviceCollection.h
+++ b/DataFormats/CaloRecHit/interface/alpaka/CaloClusterDeviceCollection.h
@@ -1,0 +1,15 @@
+
+#ifndef DataFormats_CaloRecHit_CaloClusterDeviceCollection_H
+#define DataFormats_CaloRecHit_CaloClusterDeviceCollection_H
+
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterSoA.h"
+#include <alpaka/alpaka.hpp>
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::reco {
+
+  using CaloClusterDeviceCollection = PortableCollection<::reco::CaloClusterSoA>;
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::reco
+
+#endif

--- a/DataFormats/CaloRecHit/src/alpaka/classes_cuda.h
+++ b/DataFormats/CaloRecHit/src/alpaka/classes_cuda.h
@@ -1,0 +1,4 @@
+#include "DataFormats/Common/interface/DeviceProduct.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterSoA.h"
+#include "DataFormats/CaloRecHit/interface/alpaka/CaloClusterDeviceCollection.h"

--- a/DataFormats/CaloRecHit/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/CaloRecHit/src/alpaka/classes_cuda_def.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+  <class name="alpaka_cuda_async::reco::CaloClusterDeviceCollection" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_cuda_async::reco::CaloClusterDeviceCollection>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::reco::CaloClusterDeviceCollection>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/CaloRecHit/src/alpaka/classes_rocm.h
+++ b/DataFormats/CaloRecHit/src/alpaka/classes_rocm.h
@@ -1,0 +1,4 @@
+#include "DataFormats/Common/interface/DeviceProduct.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterSoA.h"
+#include "DataFormats/CaloRecHit/interface/alpaka/CaloClusterDeviceCollection.h"

--- a/DataFormats/CaloRecHit/src/alpaka/classes_rocm_def.xml
+++ b/DataFormats/CaloRecHit/src/alpaka/classes_rocm_def.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+  <class name="alpaka_rocm_async::reco::CaloClusterDeviceCollection" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_rocm_async::reco::CaloClusterDeviceCollection>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::reco::CaloClusterDeviceCollection>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/CaloRecHit/src/classes.cc
+++ b/DataFormats/CaloRecHit/src/classes.cc
@@ -1,0 +1,4 @@
+#include "DataFormats/Portable/interface/PortableHostCollectionReadRules.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterHostCollection.h"
+
+SET_PORTABLEHOSTCOLLECTION_READ_RULES(reco::CaloClusterHostCollection);

--- a/DataFormats/CaloRecHit/src/classes.h
+++ b/DataFormats/CaloRecHit/src/classes.h
@@ -6,3 +6,5 @@
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
 #include "DataFormats/CaloRecHit/interface/CaloClusterCollection.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterSoA.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterHostCollection.h"

--- a/DataFormats/CaloRecHit/src/classes_def.xml
+++ b/DataFormats/CaloRecHit/src/classes_def.xml
@@ -29,4 +29,16 @@
   <class name="edm::ValueMap<reco::CaloClusterPtrVector>" />
   <class name="edm::Wrapper<edm::ValueMap<reco::CaloClusterPtr> >" />
   <class name="edm::Wrapper<edm::ValueMap<reco::CaloClusterPtrVector> >" />
+
+  <class name="reco::CaloClusterHostCollection"/>
+  <class name="reco::CaloClusterHostCollection::Layout"/>
+  <class name="reco::CaloClusterSoA"/>
+  <class name="reco::CaloClusterSoA::View"/>
+  <class name="reco::CaloClusterSoAPosition<128, false>"/>
+  <class name="reco::CaloClusterSoAEnergy<128, false>"/>
+  <class name="reco::CaloClusterSoAIndexes<128, false>"/>
+  <class name="reco::CaloClusterSoATiming<128, false>"/>
+
+  <class name="edm::Wrapper<reco::CaloClusterHostCollection>" splitLevel="0"/>
+
 </lcgdict>

--- a/DataFormats/HGCalReco/interface/Common.h
+++ b/DataFormats/HGCalReco/interface/Common.h
@@ -49,6 +49,8 @@ namespace ticl {
   //constants
   constexpr double mpion = 0.13957;
   constexpr float mpion2 = mpion * mpion;
+  constexpr double mmuon = 0.1056583745;
+  constexpr float mmuon2 = mmuon * mmuon;
   typedef math::XYZVectorF Vector;
 
   inline Trackster::ParticleType tracksterParticleTypeFromPdgId(int pdgId, int charge) {

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -444,7 +444,7 @@ namespace edm {
     void watchPreOpenOutputFiles(PreOpenOutputFiles::slot_type const& iSlot) {
       preOpenOutputFilesSignal_.connect(iSlot);
     }
-    AR_WATCH_USING_METHOD_1(watchPreOpenOutputFiles)
+    AR_WATCH_USING_METHOD_0(watchPreOpenOutputFiles)
 
     /// signal is emitted after the framework asks OutputModules to open output files
     typedef signalslot::Signal<void()> PostOpenOutputFiles;
@@ -452,7 +452,7 @@ namespace edm {
     void watchPostOpenOutputFiles(PostOpenOutputFiles::slot_type const& iSlot) {
       postOpenOutputFilesSignal_.connect_front(iSlot);
     }
-    AR_WATCH_USING_METHOD_1(watchPostOpenOutputFiles)
+    AR_WATCH_USING_METHOD_0(watchPostOpenOutputFiles)
 
     /// signal is emitted before the framework asks OutputModules to close output files
     // Note an OutputModule may decide to close and open files by itself, those are not covered by this signal
@@ -461,7 +461,7 @@ namespace edm {
     void watchPreCloseOutputFiles(PreCloseOutputFiles::slot_type const& iSlot) {
       preCloseOutputFilesSignal_.connect(iSlot);
     }
-    AR_WATCH_USING_METHOD_1(watchPreCloseOutputFiles)
+    AR_WATCH_USING_METHOD_0(watchPreCloseOutputFiles)
 
     /// signal is emitted after the framework asks OutputModules to close output files
     typedef signalslot::Signal<void()> PostCloseOutputFiles;
@@ -469,7 +469,7 @@ namespace edm {
     void watchPostCloseOutputFiles(PostCloseOutputFiles::slot_type const& iSlot) {
       postCloseOutputFilesSignal_.connect_front(iSlot);
     }
-    AR_WATCH_USING_METHOD_1(watchPostCloseOutputFiles)
+    AR_WATCH_USING_METHOD_0(watchPostCloseOutputFiles)
 
     typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleBeginStream;
     PreModuleBeginStream preModuleBeginStreamSignal_;

--- a/FWStorage/TFileAdaptor/src/TFileAdaptor.cc
+++ b/FWStorage/TFileAdaptor/src/TFileAdaptor.cc
@@ -192,10 +192,12 @@ TFileAdaptor::TFileAdaptor(edm::ParameterSet const& pset, edm::ActivityRegistry&
     addType(mgr, "^dcap:");
   if (!native("gsidcap"))
     addType(mgr, "^gsidcap:");
-  if (!native("root"))
-    addType(mgr, "^root:", 1);  // See comments in addType
-  if (!native("root"))
-    addType(mgr, "^[x]?root:", 1);  // See comments in addType
+  if (!native("root")) {
+    // See comments in addType
+    addType(mgr, "^root:", 1);
+    addType(mgr, "^[x]?root:", 1);
+    addType(mgr, "^[x]?root[s]?:", 1);
+  }
 
   // Make sure the TStorageFactoryFile can be loaded regardless of the header auto-parsing setting
   {

--- a/FWStorage/TFileAdaptor/test/tfileTest.cpp
+++ b/FWStorage/TFileAdaptor/test/tfileTest.cpp
@@ -18,9 +18,18 @@
 
 int main(int argc, char* argv[]) {
   // This list should replicate the addHandler calls in TFileAdaptor
-  std::array<char const*, 10> const protocols = {
-      {"^file:", "^http:", "^http[s]?:", "^ftp:", "^web:", "^dcache:", "^dcap:", "^gsidcap:", "^root:", "^[x]?root:"}};
-  std::array<char const*, 10> const uris{{"file:foo",
+  std::array<char const*, 11> const protocols = {{"^file:",
+                                                  "^http:",
+                                                  "^http[s]?:",
+                                                  "^ftp:",
+                                                  "^web:",
+                                                  "^dcache:",
+                                                  "^dcap:",
+                                                  "^gsidcap:",
+                                                  "^root:",
+                                                  "^[x]?root:",
+                                                  "^[x]?root[s]?:"}};
+  std::array<char const*, 11> const uris{{"file:foo",
                                           "http://foo",
                                           "https://foo",
                                           "ftp://foo",
@@ -29,7 +38,8 @@ int main(int argc, char* argv[]) {
                                           "dcap://foo",
                                           "gsidcap://foo",
                                           "root://foo",
-                                          "xroot://foo"}};
+                                          "xroot://foo",
+                                          "xroots://foo"}};
 
   char const* tStorageFactoryFileFunc = "TStorageFactoryFile(char const*, Option_t*, char const*, Int_t)";
   char const* tStorageFactoryFileFuncNet =

--- a/GeneratorInterface/Pythia8Interface/interface/Py8HMC3GunBase.h
+++ b/GeneratorInterface/Pythia8Interface/interface/Py8HMC3GunBase.h
@@ -43,7 +43,8 @@ namespace gen {
     ~Py8HMC3GunBase() override {}
 
     virtual bool residualDecay();  // common func
-    bool initializeForInternalPartons() override;
+    bool initializeGen();
+    //bool initializeForInternalPartons() override;
     void finalizeEvent() override;
     void statistics() override;
 

--- a/GeneratorInterface/Pythia8Interface/plugins/HMC3Py8EGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/HMC3Py8EGun.cc
@@ -17,6 +17,7 @@ namespace gen {
     HMC3Py8EGun(edm::ParameterSet const&);
     ~HMC3Py8EGun() override {}
 
+    bool initializeForInternalPartons() override;
     bool generatePartonsAndHadronize() override;
     const char* classname() const override;
     void evtGenDecay();
@@ -40,13 +41,17 @@ namespace gen {
     fMinE = pgun_params.getParameter<double>("MinE");                                      // ,  0.);
     fMaxE = pgun_params.getParameter<double>("MaxE");                                      // ,  0.);
     fAddAntiParticle = pgun_params.getParameter<bool>("AddAntiParticle");                  //, false) ;
+  }
 
+  bool HMC3Py8EGun::initializeForInternalPartons() {
+    initializeGen();
     if (useEvtGen) {
       edm::LogInfo("Pythia8Interface") << "Creating and initializing pythia8 EvtGen plugin";
       evtgenDecays = std::make_shared<Pythia8::EvtGenDecays>(fMasterGen.get(), evtgenDecFile, evtgenPdlFile);
       for (unsigned int i = 0; i < evtgenUserFiles.size(); i++)
         evtgenDecays->readDecayFile(evtgenUserFiles.at(i));
     }
+    return true;
   }
 
   bool HMC3Py8EGun::generatePartonsAndHadronize() {

--- a/GeneratorInterface/Pythia8Interface/src/Py8HMC3GunBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8HMC3GunBase.cc
@@ -34,7 +34,7 @@ namespace gen {
 
   // specific to Py8GunHad !!!
   //
-  bool Py8HMC3GunBase::initializeForInternalPartons() {
+  bool Py8HMC3GunBase::initializeGen() {
     // NO MATTER what was this setting below, override it before init
     // - this is essencial for the PGun mode
 

--- a/GeneratorInterface/Pythia8Interface/test/Py8hmc3EGun_EvtGen_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/Py8hmc3EGun_EvtGen_cfg.py
@@ -1,0 +1,70 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
+process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
+
+process.source = cms.Source("EmptySource")
+
+process.generator = cms.EDFilter("Pythia8HepMC3EGun",
+
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(True),
+    useEvtGenPlugin = cms.PSet(),
+    #evtgenDecFile = cms.string("mydecfile"),
+    #evtgenPdlFile = cms.string("mypdlfile"),
+    evtgenUserFile = cms.vstring('GeneratorInterface/Pythia8Interface/test/evtgen_userfile.dec'),
+    PGunParameters = cms.PSet(
+       ParticleID = cms.vint32(521),
+       AddAntiParticle = cms.bool(False),
+       MinPhi = cms.double(-3.14159265359),
+       MaxPhi = cms.double(3.14159265359),
+       MinE = cms.double(100.0),
+       MaxE = cms.double(200.0),
+       MinEta = cms.double(0.0),
+       MaxEta = cms.double(2.4)
+    ),
+
+    PythiaParameters = cms.PSet(
+        py8Settings = cms.vstring(''),
+        parameterSets = cms.vstring('py8Settings')
+    )
+        
+)
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        default = cms.untracked.PSet(
+            limit = cms.untracked.int32(2)
+        ),
+        enable = cms.untracked.bool(True)
+    )
+)
+
+process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+    generator = cms.PSet(
+        initialSeed = cms.untracked.uint32(123456789),
+        engineName = cms.untracked.string('HepJamesRandom')
+    )
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10)
+)
+
+process.GEN = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('Py8hmc3EGun_EvtGen.root')
+)
+
+
+process.p = cms.Path(process.generator)
+process.outpath = cms.EndPath(process.GEN)
+
+process.schedule = cms.Schedule(process.p, process.outpath)
+

--- a/GeneratorInterface/Pythia8Interface/test/pythia8hmc3ex11_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/pythia8hmc3ex11_cfg.py
@@ -1,0 +1,60 @@
+#Using evtgen plugin
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+
+process.load("Configuration.StandardSequences.SimulationRandomNumberGeneratorSeeds_cff")
+
+process.source = cms.Source("EmptySource")
+
+process.generator = cms.EDFilter("Pythia8HepMC3GeneratorFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    useEvtGenPlugin = cms.PSet(),
+    #evtgenDecFile = cms.string("mydecfile"),
+    #evtgenPdlFile = cms.string("mypdlfile"),
+    evtgenUserFile = cms.vstring('GeneratorInterface/Pythia8Interface/test/evtgen_userfile.dec'),
+    PythiaParameters = cms.PSet(
+        pythia8_example11 = cms.vstring('HardQCD:hardbbbar = on'),
+        parameterSets = cms.vstring('pythia8_example11')
+    )
+)
+
+# in order to use lhapdf PDF add a line like this to pythia8_example02:
+# 'PDF:pSet = LHAPDF5:MRST2004nlo.LHpdf'
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        default = cms.untracked.PSet(
+            limit = cms.untracked.int32(2)
+        ),
+        enable = cms.untracked.bool(True)
+    )
+)
+
+process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+    generator = cms.PSet(
+        initialSeed = cms.untracked.uint32(123456789),
+    )
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10)
+)
+
+process.GEN = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('pythia8hmc3ex11.root')
+)
+
+process.p = cms.Path(process.generator)
+process.outpath = cms.EndPath(process.GEN)
+
+process.schedule = cms.Schedule(process.p, process.outpath)

--- a/RecoHGCal/TICL/interface/TICLInterpretationAlgoBase.h
+++ b/RecoHGCal/TICL/interface/TICLInterpretationAlgoBase.h
@@ -28,6 +28,11 @@ namespace edm {
   class EventSetup;
 }  // namespace edm
 namespace ticl {
+  // Sentinel a muon interpretation pass writes into resultCandidate for a track it
+  // rejected (the trajectory points to a shower, so it is not a muon). The producer
+  // routes such tracks to the next (general) pass instead of building a muon candidate.
+  constexpr int kMuonRejected = -2;
+
   template <typename T>
   class TICLInterpretationAlgoBase {
   public:
@@ -79,10 +84,14 @@ namespace ticl {
           : tkTime_h(tkT), tkTimeErr_h(tkTE), tkQuality_h(tkQ), tkBeta_h(tkB), tkPath_h(tkP), tkMtdPos_h(mtdPos) {}
     };
 
+    // maskedTracksters (indexed over input.tracksters) lets several interpretation
+    // passes run in sequence: a pass marks the tracksters it consumes, and later
+    // passes skip them. Empty or all-false means "nothing already consumed".
     virtual void makeCandidates(const Inputs& input,
                                 edm::Handle<MtdHostCollection> inputTiming_h,
                                 std::vector<Trackster>& resultTracksters,
-                                std::vector<int>& resultCandidate) = 0;
+                                std::vector<int>& resultCandidate,
+                                std::vector<bool>& maskedTracksters) = 0;
 
     virtual void initialize(const HGCalDDDConstants* hgcons,
                             const hgcal::RecHitTools rhtools,

--- a/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.cc
@@ -347,7 +347,8 @@ void GNNInterpretationAlgo::buildGraphFromNodes(const std::tuple<Vector, Algebra
 void GNNInterpretationAlgo::makeCandidates(const Inputs& input,
                                            edm::Handle<MtdHostCollection> inputTiming_h,
                                            std::vector<Trackster>& resultTracksters,
-                                           std::vector<int>& resultCandidate) {
+                                           std::vector<int>& resultCandidate,
+                                           std::vector<bool>& maskedTracksters) {
   const auto& tracks = *input.tracksHandle;
   const auto& maskTracks = input.maskedTracks;
   const auto& tracksters = input.tracksters;
@@ -445,6 +446,11 @@ void GNNInterpretationAlgo::makeCandidates(const Inputs& input,
   std::vector<std::vector<unsigned>> trackToTracksters(tracks.size());
   std::vector<std::vector<std::pair<unsigned, float>>> trackToScores(tracks.size());
   std::vector<bool> tracksterAvailable(tracksters.size(), true);
+  // Tracksters consumed by an earlier interpretation pass (e.g. muon MIP tracksters)
+  // are unavailable: they are neither re-linked to a track nor emitted as neutrals.
+  for (size_t i = 0; i < tracksters.size() && i < maskedTracksters.size(); ++i)
+    if (maskedTracksters[i])
+      tracksterAvailable[i] = false;
 
   auto runInferenceForTrack = [&](unsigned trkId,
                                   const std::vector<TrackPropInfo>& tkProps,

--- a/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.h
+++ b/RecoHGCal/TICL/plugins/GNNInterpretationAlgo.h
@@ -43,7 +43,8 @@ namespace ticl {
     void makeCandidates(const Inputs &input,
                         edm::Handle<MtdHostCollection> inputTiming_h,
                         std::vector<Trackster> &resultTracksters,
-                        std::vector<int> &resultCandidate) override;
+                        std::vector<int> &resultCandidate,
+                        std::vector<bool> &maskedTracksters) override;
 
     void initialize(const HGCalDDDConstants *hgcons,
                     const hgcal::RecHitTools rhtools,

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
@@ -205,7 +205,8 @@ bool GeneralInterpretationAlgo::timeAndEnergyCompatible(float &total_raw_energy,
 void GeneralInterpretationAlgo::makeCandidates(const Inputs &input,
                                                edm::Handle<MtdHostCollection> inputTiming_h,
                                                std::vector<Trackster> &resultTracksters,
-                                               std::vector<int> &resultCandidate) {
+                                               std::vector<int> &resultCandidate,
+                                               std::vector<bool> &maskedTracksters) {
   bool useMTDTiming = inputTiming_h.isValid();
   const auto tkH = input.tracksHandle;
   const auto maskTracks = input.maskedTracks;
@@ -319,6 +320,12 @@ void GeneralInterpretationAlgo::makeCandidates(const Inputs &input,
   trackstersInTrackIndices.resize(tracks.size());
 
   std::vector<bool> chargedMask(tracksters.size(), true);
+  // Tracksters already consumed by an earlier interpretation pass (e.g. muon MIP
+  // tracksters) are unavailable here: they are neither linked to a track nor emitted
+  // as neutral candidates.
+  for (size_t i = 0; i < tracksters.size() && i < maskedTracksters.size(); ++i)
+    if (maskedTracksters[i])
+      chargedMask[i] = false;
   for (unsigned &i : candidateTrackIds) {
     if (tsNearTk[i].empty() && tsNearTkAtInt[i].empty()) {  // nothing linked to track, make charged hadrons
       continue;

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.h
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.h
@@ -20,7 +20,8 @@ namespace ticl {
     void makeCandidates(const Inputs &input,
                         edm::Handle<MtdHostCollection> inputTiming_h,
                         std::vector<Trackster> &resultTracksters,
-                        std::vector<int> &resultCandidate) override;
+                        std::vector<int> &resultCandidate,
+                        std::vector<bool> &maskedTracksters) override;
 
     void initialize(const HGCalDDDConstants *hgcons,
                     const hgcal::RecHitTools rhtools,

--- a/RecoHGCal/TICL/plugins/MuonInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/MuonInterpretationAlgo.cc
@@ -1,0 +1,112 @@
+#include "RecoHGCal/TICL/plugins/MuonInterpretationAlgo.h"
+
+#include "DataFormats/Math/interface/deltaR.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+// v0 of the Muon-POG HGCAL muon interpretation. It captures the architecture (point the
+// track into HGCAL, collect the tracksters around the trajectory, require a MIP / not-
+// energetic signature, and consume the MIP tracksters) with a rule-based decision as a
+// placeholder for the neural network. TODOs marked below are the upgrade path:
+//   - replace the direction-based association with full track propagation to the HGCAL
+//     layers (as GeneralInterpretationAlgo does) and per-layer layer-cluster collection;
+//   - run the ONNX muon-ID network over those layer clusters (onnx_model_path_).
+
+using namespace ticl;
+
+MuonInterpretationAlgo::MuonInterpretationAlgo(const edm::ParameterSet &conf, edm::ConsumesCollector iC)
+    : TICLInterpretationAlgoBase(conf, iC),
+      delta_tk_ts_(conf.getParameter<double>("delta_tk_ts")),
+      mip_energy_max_(conf.getParameter<double>("mip_energy_max")),
+      onnx_model_path_(conf.getParameter<std::string>("onnx_model_path")),
+      hgcons_(nullptr) {}
+
+MuonInterpretationAlgo::~MuonInterpretationAlgo() {}
+
+void MuonInterpretationAlgo::initialize(const HGCalDDDConstants *hgcons,
+                                        const hgcal::RecHitTools rhtools,
+                                        const edm::ESHandle<MagneticField> bfieldH,
+                                        const edm::ESHandle<Propagator> propH) {
+  hgcons_ = hgcons;
+  rhtools_ = rhtools;
+  bfield_ = bfieldH;
+  propagator_ = propH;
+}
+
+bool MuonInterpretationAlgo::isMuonLike(double nearbyEnergy, unsigned /*nNearbyTracksters*/) const {
+  // TODO: when onnx_model_path_ is set, run the muon-ID network over the surrounding
+  // layer clusters and use its score here. Until then, the Muon-POG "not energetic"
+  // requirement is the decision: a muon deposits a MIP, so the tracksters around its
+  // trajectory carry little energy.
+  return nearbyEnergy < mip_energy_max_;
+}
+
+void MuonInterpretationAlgo::makeCandidates(const Inputs &input,
+                                            edm::Handle<MtdHostCollection> /*inputTiming_h*/,
+                                            std::vector<Trackster> &resultTracksters,
+                                            std::vector<int> &resultCandidate,
+                                            std::vector<bool> &maskedTracksters) {
+  const auto &tracks = *input.tracksHandle;
+  const auto &maskTracks = input.maskedTracks;
+  const auto &tracksters = input.tracksters;
+  if (maskedTracksters.size() < tracksters.size())
+    maskedTracksters.resize(tracksters.size(), false);
+
+  for (size_t iTrack = 0; iTrack < tracks.size(); ++iTrack) {
+    if (!maskTracks[iTrack])
+      continue;
+    const auto &tk = tracks[iTrack];
+    // TODO: propagate the track to the HGCAL layers; here we use the outer track
+    // direction (or the momentum direction) as the HGCAL entry direction, which is a
+    // good approximation for a minimally-bending muon.
+    const auto dir = tk.outerOk() ? tk.outerMomentum() : tk.momentum();
+    const double tkEta = dir.eta();
+    const double tkPhi = dir.phi();
+
+    // Collect the tracksters whose barycenter lies within the (eta,phi) window around
+    // the trajectory, and sum their raw energy (the "is it energetic?" measure).
+    std::vector<unsigned> nearby;
+    double nearbyEnergy = 0.;
+    for (unsigned iTs = 0; iTs < tracksters.size(); ++iTs) {
+      if (maskedTracksters[iTs])
+        continue;
+      const auto &bary = tracksters[iTs].barycenter();
+      if (bary.eta() * tkEta < 0.)  // same endcap
+        continue;
+      if (reco::deltaR(bary.eta(), bary.phi(), tkEta, tkPhi) < delta_tk_ts_) {
+        nearby.push_back(iTs);
+        nearbyEnergy += tracksters[iTs].raw_energy();
+      }
+    }
+
+    if (!isMuonLike(nearbyEnergy, nearby.size())) {
+      // Trajectory points to a shower: this is not a muon. Flag it so the producer
+      // routes it to the general interpretation instead of building a muon candidate.
+      resultCandidate[iTrack] = kMuonRejected;
+      continue;
+    }
+
+    // Muon: consume the MIP tracksters (mask them) and merge them into one trackster so
+    // the producer can attach it to the muon candidate; the candidate energy itself is
+    // taken from the track momentum by the producer.
+    if (!nearby.empty()) {
+      Trackster muonTrackster;
+      for (unsigned iTs : nearby) {
+        muonTrackster.mergeTracksters(tracksters[iTs]);
+        maskedTracksters[iTs] = true;
+      }
+      resultCandidate[iTrack] = static_cast<int>(resultTracksters.size());
+      resultTracksters.push_back(muonTrackster);
+    } else {
+      resultCandidate[iTrack] = -1;  // muon with no HGCAL deposit: track-only candidate
+    }
+  }
+}
+
+void MuonInterpretationAlgo::fillPSetDescription(edm::ParameterSetDescription &desc) {
+  desc.add<double>("delta_tk_ts", 0.1)->setComment("(eta,phi) window to collect tracksters around the trajectory.");
+  desc.add<double>("mip_energy_max", 10.0)
+      ->setComment("Max summed raw energy [GeV] around the trajectory for a MIP-like (muon) signature.");
+  desc.add<std::string>("onnx_model_path", "")
+      ->setComment("ONNX muon-ID model; empty falls back to the rule-based MIP test.");
+  TICLInterpretationAlgoBase::fillPSetDescription(desc);
+}

--- a/RecoHGCal/TICL/plugins/MuonInterpretationAlgo.h
+++ b/RecoHGCal/TICL/plugins/MuonInterpretationAlgo.h
@@ -1,0 +1,76 @@
+#ifndef RecoHGCal_TICL_MuonInterpretationAlgo_h
+#define RecoHGCal_TICL_MuonInterpretationAlgo_h
+
+// Muon interpretation for TICL candidates. A muon crosses HGCAL as a MIP: it should
+// NOT be built from the small calorimetric deposit it leaves (as the general
+// interpretation would), but recognised as a muon and built from the track momentum,
+// with its MIP tracksters consumed so they do not resurface as neutral candidates.
+//
+// This is where the Muon-POG HGCAL muon identification belongs. For each candidate
+// track this algo:
+//   1. points/propagates the track into HGCAL and collects the layer clusters /
+//      tracksters in an (eta,phi) window around the trajectory;
+//   2. checks the trajectory does NOT coincide with an energetic trackster (a muon is
+//      MIP-like, not a shower) - the "not energetic" requirement;
+//   3. runs a neural network over the surrounding layer clusters to decide muon vs not
+//      (ONNX model, path configurable like the other TICL inference). The trained
+//      weights are a Muon-POG deliverable; until a model is provided the decision falls
+//      back to the rule-based MIP/not-energetic test so the algo is runnable.
+// A track accepted as a muon has its MIP tracksters masked (consumed) and is reported
+// so the producer builds a muon candidate from the track momentum.
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "RecoHGCal/TICL/interface/TICLInterpretationAlgoBase.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+
+#include <memory>
+#include <string>
+
+namespace cms::Ort {
+  class ONNXRuntime;
+}
+
+namespace ticl {
+
+  class MuonInterpretationAlgo : public TICLInterpretationAlgoBase<reco::Track> {
+  public:
+    MuonInterpretationAlgo(const edm::ParameterSet &conf, edm::ConsumesCollector iC);
+    ~MuonInterpretationAlgo() override;
+
+    void makeCandidates(const Inputs &input,
+                        edm::Handle<MtdHostCollection> inputTiming_h,
+                        std::vector<Trackster> &resultTracksters,
+                        std::vector<int> &resultCandidate,
+                        std::vector<bool> &maskedTracksters) override;
+
+    void initialize(const HGCalDDDConstants *hgcons,
+                    const hgcal::RecHitTools rhtools,
+                    const edm::ESHandle<MagneticField> bfieldH,
+                    const edm::ESHandle<Propagator> propH) override;
+
+    static void fillPSetDescription(edm::ParameterSetDescription &iDesc);
+
+  private:
+    // NN muon score over the layer clusters around the trajectory. Falls back to the
+    // rule-based MIP/not-energetic decision when no ONNX model is configured.
+    bool isMuonLike(double nearbyEnergy, unsigned nNearbyTracksters) const;
+
+    // (eta,phi) window used to collect tracksters around the track direction.
+    const double delta_tk_ts_;
+    // Max summed raw energy of the tracksters around the trajectory for a MIP-like
+    // (muon) signature; above this the track points to a shower and is not a muon.
+    const double mip_energy_max_;
+    // ONNX muon-ID model (empty -> rule-based fallback). Loaded via the global cache.
+    const std::string onnx_model_path_;
+
+    const HGCalDDDConstants *hgcons_;
+    hgcal::RecHitTools rhtools_;
+    edm::ESHandle<MagneticField> bfield_;
+    edm::ESHandle<Propagator> propagator_;
+  };
+
+}  // namespace ticl
+
+#endif

--- a/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
@@ -79,6 +79,7 @@ private:
                               F func) const;
 
   std::unique_ptr<TICLInterpretationAlgoBase<reco::Track>> generalInterpretationAlgo_;
+  std::unique_ptr<TICLInterpretationAlgoBase<reco::Track>> muonInterpretationAlgo_;
   std::vector<edm::EDGetTokenT<std::vector<Trackster>>> egamma_tracksters_tokens_;
   std::vector<edm::EDGetTokenT<std::vector<std::vector<unsigned>>>> egamma_tracksterlinks_tokens_;
 
@@ -210,6 +211,11 @@ TICLCandidateProducer::TICLCandidateProducer(const edm::ParameterSet &ps, const 
   auto algoType = interpretationPSet.getParameter<std::string>("type");
   generalInterpretationAlgo_ =
       TICLGeneralInterpretationPluginFactory::get()->create(algoType, interpretationPSet, consumesCollector());
+
+  auto muonInterpretationPSet = ps.getParameter<edm::ParameterSet>("muonInterpretationDescPSet");
+  auto muonAlgoType = muonInterpretationPSet.getParameter<std::string>("type");
+  muonInterpretationAlgo_ =
+      TICLGeneralInterpretationPluginFactory::get()->create(muonAlgoType, muonInterpretationPSet, consumesCollector());
 }
 
 std::unique_ptr<ticl::TICLONNXGlobalCache> TICLCandidateProducer::initializeGlobalCache(
@@ -229,6 +235,7 @@ void TICLCandidateProducer::beginRun(edm::Run const &iEvent, edm::EventSetup con
   bfield_ = es.getHandle(bfield_token_);
   propagator_ = es.getHandle(propagator_token_);
   generalInterpretationAlgo_->initialize(hgcons_, rhtools_, bfield_, propagator_);
+  muonInterpretationAlgo_->initialize(hgcons_, rhtools_, bfield_, propagator_);
 
   trackingGeometry_ = es.getHandle(trackingGeometry_token_);
 }
@@ -326,6 +333,55 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
   maskTracks.resize(tracks.size());
   filterTracks(tracks_h, muons_h, cutTk_, tkEnergyCut_, maskTracks);
 
+  // Split the selected tracks: identified muons go to the muon interpretation pass
+  // (built from the track momentum), the rest to the general pass.
+  std::vector<bool> muonTrackMask(tracks.size(), false);
+  std::vector<bool> generalTrackMask(maskTracks);
+  for (size_t i = 0; i < tracks.size(); ++i) {
+    if (!maskTracks[i])
+      continue;
+    auto trackRef = edm::Ref<reco::TrackCollection>(tracks_h, i);
+    const int muId = PFMuonAlgo::muAssocToTrack(trackRef, *muons_h);
+    const reco::MuonRef muonRef(muons_h, muId);
+    if (muonRef.isNonnull() and PFMuonAlgo::isMuon(muonRef)) {
+      muonTrackMask[i] = true;
+      generalTrackMask[i] = false;
+    }
+  }
+
+  const typename TICLInterpretationAlgoBase<reco::Track>::Inputs muonInput(evt,
+                                                                           es,
+                                                                           layerClusters,
+                                                                           layerClustersTimes,
+                                                                           generalTrackstersSpan,
+                                                                           generalTracksterLinksGlobalId,
+                                                                           tracks_h,
+                                                                           muonTrackMask);
+  auto resultCandidates = std::make_unique<std::vector<TICLCandidate>>();
+  std::vector<int> muonInTrackIndices(tracks.size(), -1);
+  std::vector<int> trackstersInTrackIndices(tracks.size(), -1);
+
+  //TODO
+  //egammaInterpretationAlg_->makecandidates(inputGSF, inputTiming, *resultTrackstersMerged, trackstersInGSFTrackIndices)
+  // mask generalTracks associated to GSFTrack linked in egammaInterpretationAlgo_
+
+  // Tracksters consumed across interpretation passes (indexed over the input span). The
+  // muon pass runs first: it masks the MIP tracksters it consumes and reports, per
+  // muon-candidate track, the consumed trackster (>=0), no trackster (-1, a track-only
+  // muon), or a rejection (kMuonRejected: the trajectory points to a shower).
+  std::vector<bool> maskedInputTracksters(generalTrackstersSpan.size(), false);
+  muonInterpretationAlgo_->makeCandidates(
+      muonInput, inputTiming_h, *resultTracksters, muonInTrackIndices, maskedInputTracksters);
+
+  // A track the muon pass rejected is not a muon: route it back to the general pass so
+  // it is reconstructed there (and no muon candidate is built for it below).
+  for (size_t iTrack = 0; iTrack < tracks.size(); ++iTrack) {
+    if (muonTrackMask[iTrack] && muonInTrackIndices[iTrack] == kMuonRejected) {
+      muonTrackMask[iTrack] = false;
+      generalTrackMask[iTrack] = true;
+    }
+  }
+
   const typename TICLInterpretationAlgoBase<reco::Track>::Inputs input(evt,
                                                                        es,
                                                                        layerClusters,
@@ -333,16 +389,9 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
                                                                        generalTrackstersSpan,
                                                                        generalTracksterLinksGlobalId,
                                                                        tracks_h,
-                                                                       maskTracks);
-
-  auto resultCandidates = std::make_unique<std::vector<TICLCandidate>>();
-  std::vector<int> trackstersInTrackIndices(tracks.size(), -1);
-
-  //TODO
-  //egammaInterpretationAlg_->makecandidates(inputGSF, inputTiming, *resultTrackstersMerged, trackstersInGSFTrackIndices)
-  // mask generalTracks associated to GSFTrack linked in egammaInterpretationAlgo_
-
-  generalInterpretationAlgo_->makeCandidates(input, inputTiming_h, *resultTracksters, trackstersInTrackIndices);
+                                                                       generalTrackMask);
+  generalInterpretationAlgo_->makeCandidates(
+      input, inputTiming_h, *resultTracksters, trackstersInTrackIndices, maskedInputTracksters);
 
   assignPCAtoTracksters(*resultTracksters,
                         layerClusters,
@@ -357,9 +406,30 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
 
   std::vector<bool> maskTracksters(resultTracksters->size(), true);
   edm::OrphanHandle<std::vector<Trackster>> resultTracksters_h = evt.put(std::move(resultTracksters));
-  //create ChargedCandidates
+
+  // Muon candidates: energy from the track momentum (pdgId 13), attaching the MIP
+  // trackster the muon pass associated (if any) and masking it so it is not re-emitted.
+  for (size_t iTrack = 0; iTrack < tracks.size(); ++iTrack) {
+    if (!muonTrackMask[iTrack])
+      continue;
+    auto trackPtr = edm::Ptr<reco::Track>(tracks_h, iTrack);
+    auto const &tk = *trackPtr;
+    const int tracksterId = muonInTrackIndices[iTrack];
+    edm::Ptr<Trackster> tracksterPtr;
+    if (tracksterId >= 0) {
+      tracksterPtr = edm::Ptr<Trackster>(resultTracksters_h, tracksterId);
+      maskTracksters[tracksterId] = false;
+    }
+    TICLCandidate muonCandidate(trackPtr, tracksterPtr);
+    muonCandidate.setPdgId(13 * tk.charge());
+    math::PtEtaPhiMLorentzVector p4Polar(tk.pt(), tk.eta(), tk.phi(), ticl::mmuon);
+    muonCandidate.setP4(p4Polar);
+    resultCandidates->push_back(muonCandidate);
+  }
+
+  //create ChargedCandidates (non-muon tracks)
   for (size_t iTrack = 0; iTrack < tracks.size(); iTrack++) {
-    if (maskTracks[iTrack]) {
+    if (generalTrackMask[iTrack]) {
       auto const tracksterId = trackstersInTrackIndices[iTrack];
       auto trackPtr = edm::Ptr<reco::Track>(tracks_h, iTrack);
       if (tracksterId != -1 and !maskTracksters.empty()) {
@@ -367,18 +437,6 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
         TICLCandidate chargedCandidate(trackPtr, tracksterPtr);
         resultCandidates->push_back(chargedCandidate);
         maskTracksters[tracksterId] = false;
-      } else {
-        //charged candidates track only
-        auto trackRef = edm::Ref<reco::TrackCollection>(tracks_h, iTrack);
-        const int muId = PFMuonAlgo::muAssocToTrack(trackRef, *muons_h);
-        const reco::MuonRef muonRef = reco::MuonRef(muons_h, muId);
-        if (muonRef.isNonnull() and muonRef->isGlobalMuon()) {
-          // create muon candidate
-          edm::Ptr<Trackster> tracksterPtr;
-          TICLCandidate chargedCandidate(trackPtr, tracksterPtr);
-          chargedCandidate.setPdgId(13 * trackPtr.get()->charge());
-          resultCandidates->push_back(chargedCandidate);
-        }
       }
     }
   }
@@ -530,6 +588,9 @@ void TICLCandidateProducer::fillDescriptions(edm::ConfigurationDescriptions &des
   edm::ParameterSetDescription desc;
   edm::ParameterSetDescription interpretationDesc;
   interpretationDesc.addNode(edm::PluginDescription<TICLGeneralInterpretationPluginFactory>("type", "General", true));
+  edm::ParameterSetDescription muonInterpretationDesc;
+  muonInterpretationDesc.addNode(edm::PluginDescription<TICLGeneralInterpretationPluginFactory>("type", "Muon", true));
+  desc.add<edm::ParameterSetDescription>("muonInterpretationDescPSet", muonInterpretationDesc);
   edm::ParameterSetDescription inferenceDesc;
   inferenceDesc.addNode(edm::PluginDescription<TracksterInferenceAlgoFactory>("type", "TracksterInferenceByPFN", true));
   desc.add<edm::ParameterSetDescription>("pluginInferenceAlgoTracksterInferenceByPFN", inferenceDesc);

--- a/RecoHGCal/TICL/plugins/TICLInterpretationPluginFactory.cc
+++ b/RecoHGCal/TICL/plugins/TICLInterpretationPluginFactory.cc
@@ -5,9 +5,11 @@
 #include "RecoHGCal/TICL/plugins/TICLInterpretationPluginFactory.h"
 #include "GeneralInterpretationAlgo.h"
 #include "GNNInterpretationAlgo.h"
+#include "MuonInterpretationAlgo.h"
 
 EDM_REGISTER_VALIDATED_PLUGINFACTORY(TICLGeneralInterpretationPluginFactory, "TICLGeneralInterpretationPluginFactory");
 EDM_REGISTER_VALIDATED_PLUGINFACTORY(TICLEGammaInterpretationPluginFactory, "TICLEGammaInterpretationPluginFactory");
 DEFINE_EDM_VALIDATED_PLUGIN(TICLGeneralInterpretationPluginFactory, ticl::GeneralInterpretationAlgo, "General");
 DEFINE_EDM_VALIDATED_PLUGIN(TICLGeneralInterpretationPluginFactory, ticl::GNNInterpretationAlgo, "GNNLink");
+DEFINE_EDM_VALIDATED_PLUGIN(TICLGeneralInterpretationPluginFactory, ticl::MuonInterpretationAlgo, "Muon");
 // DEFINE_EDM_VALIDATED_PLUGIN(TICLEGammaInterpretationPluginFactory, ticl::EGammaInterpretation, "EGamma");

--- a/RecoLocalCalo/HGCalRecProducers/plugins/BuildFile.xml
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/BuildFile.xml
@@ -1,5 +1,6 @@
 <library file="*.cc" name="RecoLocalCaloHGCalRecProducersPlugins">
   <use name="alpaka"/>
+  <use name="cluestering"/>
   <use name="fmt"/>
   <use name="tbb"/>
   <use name="CommonTools/UtilAlgos"/>
@@ -20,6 +21,7 @@
   <use name="RecoLocalCalo/HGCalRecAlgos"/>
   <use name="RecoLocalCalo/HGCalRecProducers"/>
   <flags EDM_PLUGIN="1"/>
+  <flags ALPAKA_BACKENDS="serial"/>
 </library>
 
 <!-- alpaka-based portable plugins -->
@@ -32,6 +34,7 @@
   <use name="CondFormats/DataRecord"/>
   <use name="CondFormats/HGCalObjects"/>
   <use name="DataFormats/HGCalReco"/>
+  <use name="DataFormats/CaloRecHit"/>
   <use name="DataFormats/Portable"/>
   <use name="Geometry/CaloGeometry"/>
   <use name="Geometry/HGCalCommonData"/>

--- a/RecoLocalCalo/HGCalRecProducers/plugins/BuildFile.xml
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/BuildFile.xml
@@ -6,6 +6,7 @@
   <use name="CommonTools/UtilAlgos"/>
   <use name="CondFormats/DataRecord"/>
   <use name="CondFormats/HGCalObjects"/>
+  <use name="DataFormats/CaloRecHit"/>
   <use name="DataFormats/ForwardDetId"/>
   <use name="DataFormats/HGCDigi"/>
   <use name="DataFormats/HGCRecHit"/>

--- a/RecoLocalCalo/HGCalRecProducers/plugins/BuildFile.xml
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/BuildFile.xml
@@ -28,7 +28,7 @@
 <!-- alpaka-based portable plugins -->
 <library file="alpaka/*.cc" name="RecoLocalCaloHGCalRecProducersPluginsPortable">
   <use name="alpaka"/>
-  <use name="clue"/>
+  <use name="cluestering"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Utilities"/>

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalLayerClusterHeterogeneousSoADumper.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalLayerClusterHeterogeneousSoADumper.cc
@@ -1,4 +1,4 @@
-#include "DataFormats/HGCalReco/interface/HGCalSoAClustersHostCollection.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterHostCollection.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDAnalyzer.h"
@@ -27,24 +27,27 @@ public:
     auto const& data = iEvent.get(token_);
 
     auto const view = data.view();
-    std::cout << fmt::format("hgcalSoALayerClustersProducer size = {}", view.metadata().size()) << std::endl;
-    for (int i = 0; i < data->metadata().size(); ++i) {
+    auto const position_v = view.position();
+    auto const energy_v = view.energy();
+    const int numberOfClusters = position_v.metadata().size();
+    std::cout << fmt::format("hgcalSoALayerClustersProducer size = {}", numberOfClusters) << std::endl;
+    for (int i = 0; i < numberOfClusters; ++i) {
       std::cout << fmt::format("CLUSTERS_SOA {}, energy = {:.{}f}, x = {:.{}f}, y = {:.{}f}, z= {:.{}f}",
                                i,
-                               view.energy(i),
+                               energy_v[i].energy(),
                                std::numeric_limits<float>::max_digits10,
-                               view.x(i),
+                               position_v[i].x(),
                                std::numeric_limits<float>::max_digits10,
-                               view.y(i),
+                               position_v[i].y(),
                                std::numeric_limits<float>::max_digits10,
-                               view.z(i),
+                               position_v[i].z(),
                                std::numeric_limits<float>::max_digits10)
                 << std::endl;
     }
   }
 
 private:
-  edm::EDGetTokenT<HGCalSoAClustersHostCollection> const token_;
+  edm::EDGetTokenT<reco::CaloClusterHostCollection> const token_;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalLayerClustersFromSoAProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalLayerClustersFromSoAProducer.cc
@@ -13,7 +13,7 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Math/interface/Point3D.h"
 #include "DataFormats/EgammaReco/interface/BasicClusterFwd.h"
-#include "DataFormats/HGCalReco/interface/HGCalSoAClustersHostCollection.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterHostCollection.h"
 #include "DataFormats/HGCalReco/interface/HGCalSoARecHitsExtraHostCollection.h"
 #include "DataFormats/HGCalReco/interface/HGCalSoARecHitsHostCollection.h"
 
@@ -62,27 +62,31 @@ public:
     auto const soaCells_v = deviceSoACells.view();
 
     auto const deviceView = deviceData.view();
+    auto const position_v = deviceView.position();
+    auto const energy_v = deviceView.energy();
+    auto const indexes_v = deviceView.indexes();
+    const int numberOfClusters = position_v.metadata().size();
 
     std::unique_ptr<std::vector<reco::BasicCluster>> clusters(new std::vector<reco::BasicCluster>);
-    clusters->reserve(deviceData->metadata().size());
+    clusters->reserve(numberOfClusters);
 
     // Create a vector of <clusters> locations, where each location holds a
     // vector of <nCells> floats. These vectors are used to compute the time for
     // each cluster.
-    std::vector<std::vector<float>> times(deviceData->metadata().size());
-    std::vector<std::vector<float>> timeErrors(deviceData->metadata().size());
+    std::vector<std::vector<float>> times(numberOfClusters);
+    std::vector<std::vector<float>> timeErrors(numberOfClusters);
 
-    for (int i = 0; i < deviceData->metadata().size(); ++i) {
+    for (int i = 0; i < numberOfClusters; ++i) {
       std::vector<std::pair<DetId, float>> thisCluster;
-      thisCluster.reserve(deviceView.cells(i));
-      clusters->emplace_back(deviceView.energy(i),
-                             math::XYZPoint(deviceView.x(i), deviceView.y(i), deviceView.z(i)),
+      thisCluster.reserve(position_v[i].cells());
+      clusters->emplace_back(energy_v[i].energy(),
+                             math::XYZPoint(position_v[i].x(), position_v[i].y(), position_v[i].z()),
                              reco::CaloID::DET_HGCAL_ENDCAP,
                              std::move(thisCluster),
                              algoId_);
-      clusters->back().setSeed(deviceView.seed(i));
-      times[i].reserve(deviceView.cells(i));
-      timeErrors[i].reserve(deviceView.cells(i));
+      clusters->back().setSeed(indexes_v[i].seedID());
+      times[i].reserve(position_v[i].cells());
+      timeErrors[i].reserve(position_v[i].cells());
     }
 
     // Populate hits and fractions required to compute the cluster's time.
@@ -164,7 +168,7 @@ public:
   }
 
 private:
-  edm::EDGetTokenT<HGCalSoAClustersHostCollection> const getTokenSoAClusters_;
+  edm::EDGetTokenT<reco::CaloClusterHostCollection> const getTokenSoAClusters_;
   edm::EDGetTokenT<HGCalSoARecHitsHostCollection> const getTokenSoACells_;
   edm::EDGetTokenT<HGCalSoARecHitsExtraHostCollection> const getTokenSoARecHitsExtra_;
   std::string detector_;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersAlgoWrapper.dev.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersAlgoWrapper.dev.cc
@@ -3,41 +3,82 @@
 #error ALPAKA_HOST_ONLY defined in device compilation
 #endif
 
-#include "RecoLocalCalo/HGCalRecProducers/interface/HGCalTilesConstants.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 
 #include "HGCalLayerClustersAlgoWrapper.h"
-#include "ConstantsForClusters.h"
 
-#include "CLUEAlgoAlpaka.h"
+#include "CLUEstering/CLUEstering.hpp"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   using namespace cms::alpakatools;
-  using namespace hgcal::constants;
+
+  // CLUEstering reports the seeds as one hit index per cluster, and keeps its
+  // per-hit seed flag in a buffer of its own. Copy that information over to the
+  // column the downstream modules read, and publish the number of clusters.
+  class HGCalLayerClustersMarkSeedsKernel {
+  public:
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
+                                  const int32_t* seeds,
+                                  const unsigned int numberOfClusters,
+                                  HGCalSoARecHitsExtraDeviceCollection::View outputs) const {
+      if (once_per_grid(acc)) {
+        outputs.numberOfClustersScalar() = numberOfClusters;
+      }
+      for (auto cluster : uniform_elements(acc, numberOfClusters)) {
+        outputs[seeds[cluster]].isSeed() = 1;
+      }
+    }
+  };
 
   void HGCalLayerClustersAlgoWrapper::run(Queue& queue,
                                           const unsigned int size,
                                           const float dc,
                                           const float kappa,
                                           const float outlierDeltaFactor,
+                                          std::span<const uint32_t> batchItemSizes,
                                           const HGCalSoARecHitsDeviceCollection::ConstView inputs,
                                           HGCalSoARecHitsExtraDeviceCollection::View outputs) const {
-    CLUEAlgoAlpaka<ALPAKA_ACCELERATOR_NAMESPACE::Acc1D, Queue, HGCalSiliconTilesConstants, kHGCalLayers> algoStandalone(
-        queue, dc, kappa, outlierDeltaFactor, false);
+    // Dont allow empty inputs
+    if (size == 0) {
+      return;
+    }
 
-    algoStandalone.makeClustersCMSSW(size,
-                                     inputs.dim1().data(),
-                                     inputs.dim2().data(),
-                                     inputs.layer().data(),
-                                     inputs.energy().data(),
-                                     inputs.sigmaNoise().data(),
-                                     inputs.detid().data(),
-                                     outputs.rho().data(),
-                                     outputs.delta().data(),
-                                     outputs.nearestHigher().data(),
-                                     outputs.clusterIndex().data(),
-                                     outputs.isSeed().data(),
-                                     &outputs.numberOfClustersScalar());
+    clue::ConstPointsDevice<2, float> points(queue,
+                                             size,
+                                             inputs.dim1().data(),
+                                             inputs.dim2().data(),
+                                             inputs.energy().data(),
+                                             outputs.clusterIndex().data());
+
+    // kappa * sigmaNoise for each hit.
+    points.set_density_uncertainty({inputs.sigmaNoise().data(), size});
+
+    // Following Params of CLUE
+    clue::Clusterer<2> clusterer(queue, dc, kappa, outlierDeltaFactor * dc, dc);
+
+    // One batch item per non-empty layer. CLUEstering has no notion of layers
+    // and takes the layer of a hit from its position in the collection, which is
+    // why the RecHits SoA is filled grouped by layer.
+    clusterer.make_clusters(queue,
+                            points,
+                            batchItemSizes,
+                            clue::EuclideanMetric<2, float>{},
+                            clue::FlatKernel<float>{0.5f});
+
+    // Same number of seeds as clusters
+    const auto seeds = clusterer.getSeeds();
+    const auto numberOfClusters = static_cast<unsigned int>(points.n_clusters());
+    if (numberOfClusters > 0) {
+      const uint32_t items = 64;
+      const uint32_t groups = divide_up_by(numberOfClusters, items);
+      auto workDiv = make_workdiv<Acc1D>(groups, items);
+      alpaka::exec<Acc1D>(
+          queue, workDiv, HGCalLayerClustersMarkSeedsKernel{}, seeds.data(), numberOfClusters, outputs);
+    }
+
+    //wait for the kernel above to be done reading them.
+    alpaka::wait(queue);
   }
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersAlgoWrapper.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersAlgoWrapper.h
@@ -5,15 +5,21 @@
 #include "DataFormats/HGCalReco/interface/alpaka/HGCalSoARecHitsExtraDeviceCollection.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
+#include <cstdint>
+#include <span>
+
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class HGCalLayerClustersAlgoWrapper {
   public:
+    // batchItemSizes has number of hits for each non empty layer, allowing
+    // independent clustering of layers
     void run(Queue& queue,
              const unsigned int size,
              const float dc,
              const float kappa,
              const float outlierDeltaFactor,
+             std::span<const uint32_t> batchItemSizes,
              const HGCalSoARecHitsDeviceCollection::ConstView inputs,
              HGCalSoARecHitsExtraDeviceCollection::View outputs) const;
   };

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersSoAAlgoWrapper.dev.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersSoAAlgoWrapper.dev.cc
@@ -5,6 +5,8 @@
 
 #include "CLUEAlgoAlpaka.h"
 
+#include <cstdint>
+
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   using namespace cms::alpakatools;
@@ -17,18 +19,18 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   const unsigned int numer_of_clusters,
                                   const HGCalSoARecHitsDeviceCollection::ConstView input_rechits_soa,
                                   const HGCalSoARecHitsExtraDeviceCollection::ConstView input_clusters_soa,
-                                  HGCalSoAClustersDeviceCollection::View outputs) const {
+                                  reco::CaloClusterDeviceCollection::View outputs) const {
       // make a strided loop over the kernel grid, covering up to "size" elements
-      for (int32_t i : uniform_elements(acc, input_rechits_soa.metadata().size())) {
+      for (auto i : uniform_elements(acc, input_rechits_soa.metadata().size())) {
         // Skip unassigned rechits
         if (input_clusters_soa[i].clusterIndex() == kInvalidCluster) {
           continue;
         }
         auto clIdx = input_clusters_soa[i].clusterIndex();
-        alpaka::atomicAdd(acc, &outputs[clIdx].energy(), input_rechits_soa[i].energy());
-        alpaka::atomicAdd(acc, &outputs[clIdx].cells(), 1);
+        alpaka::atomicAdd(acc, &outputs.energy()[clIdx].energy(), input_rechits_soa[i].energy());
+        alpaka::atomicAdd(acc, &outputs.position()[clIdx].cells(), 1);
         if (input_clusters_soa[i].isSeed() == 1) {
-          outputs[clIdx].seed() = input_rechits_soa[i].detid();
+          outputs.indexes()[clIdx].seedID() = input_rechits_soa[i].detid();
         }
       }
     }
@@ -43,7 +45,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   float positionDeltaRho2,
                                   const HGCalSoARecHitsDeviceCollection::ConstView input_rechits_soa,
                                   const HGCalSoARecHitsExtraDeviceCollection::ConstView input_clusters_soa,
-                                  HGCalSoAClustersDeviceCollection::View outputs,
+                                  reco::CaloClusterDeviceCollection::View outputs,
                                   HGCalSoAClustersExtraDeviceCollection::View outputs_service) const {
       // make a strided loop over the kernel grid, covering up to "size" elements
       for (int32_t hit_index : uniform_elements(acc, input_rechits_soa.metadata().size())) {
@@ -74,8 +76,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             clusterEnergy = (clusterSeed == kInvalidIndex) ? 0.f : input_rechits_soa[clusterSeed].energy();
           }
         }  // CAS
-      }  // uniform_elements
-    }  // operator()
+      }    // uniform_elements
+    }      // operator()
   };
 
   // Real Kernel position
@@ -87,10 +89,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   float positionDeltaRho2,
                                   const HGCalSoARecHitsDeviceCollection::ConstView input_rechits_soa,
                                   const HGCalSoARecHitsExtraDeviceCollection::ConstView input_clusters_soa,
-                                  HGCalSoAClustersDeviceCollection::View outputs,
+                                  reco::CaloClusterDeviceCollection::View outputs,
                                   HGCalSoAClustersExtraDeviceCollection::View outputs_service) const {
       // make a strided loop over the kernel grid, covering up to "size" elements
-      for (int32_t hit_index : uniform_elements(acc, input_rechits_soa.metadata().size())) {
+      for (auto hit_index : uniform_elements(acc, input_rechits_soa.metadata().size())) {
         const int cluster_index = input_clusters_soa[hit_index].clusterIndex();
 
         // Bail out if you are not part of any cluster
@@ -108,11 +110,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         float Wi = std::max(thresholdW0 + std::log(input_rechits_soa[hit_index].energy() /
                                                    outputs_service[cluster_index].total_weight()),
                             0.f);
-        alpaka::atomicAdd(acc, &outputs[cluster_index].x(), input_rechits_soa[hit_index].dim1() * Wi);
-        alpaka::atomicAdd(acc, &outputs[cluster_index].y(), input_rechits_soa[hit_index].dim2() * Wi);
+        alpaka::atomicAdd(acc, &outputs.position()[cluster_index].x(), input_rechits_soa[hit_index].dim1() * Wi);
+        alpaka::atomicAdd(acc, &outputs.position()[cluster_index].y(), input_rechits_soa[hit_index].dim2() * Wi);
         alpaka::atomicAdd(acc, &outputs_service[cluster_index].total_weight_log(), Wi);
       }  // uniform_elements
-    }  // operator()
+    }    // operator()
   };
 
   // Besides the final position, add also the DetId of the seed of each cluster
@@ -124,23 +126,24 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   float positionDeltaRho2,
                                   const HGCalSoARecHitsDeviceCollection::ConstView input_rechits_soa,
                                   const HGCalSoARecHitsExtraDeviceCollection::ConstView input_clusters_soa,
-                                  HGCalSoAClustersDeviceCollection::View outputs,
+                                  reco::CaloClusterDeviceCollection::View outputs,
                                   HGCalSoAClustersExtraDeviceCollection::View outputs_service) const {
       // make a strided loop over the kernel grid, covering up to "size" elements
-      for (int32_t cluster_index : uniform_elements(acc, outputs.metadata().size())) {
+      for (auto cluster_index : uniform_elements(acc, outputs.position().metadata().size())) {
         const int max_energy_index = outputs_service[cluster_index].maxEnergyIndex();
 
         if (outputs_service[cluster_index].total_weight_log() > 0.f) {
           float inv_tot_weight = 1.f / outputs_service[cluster_index].total_weight_log();
-          outputs[cluster_index].x() *= inv_tot_weight;
-          outputs[cluster_index].y() *= inv_tot_weight;
+          outputs.position()[cluster_index].x() *= inv_tot_weight;
+          outputs.position()[cluster_index].y() *= inv_tot_weight;
         } else {
-          outputs[cluster_index].x() = input_rechits_soa[max_energy_index].dim1();
-          outputs[cluster_index].y() = input_rechits_soa[max_energy_index].dim2();
+          outputs.position()[cluster_index].x() = input_rechits_soa[max_energy_index].dim1();
+          outputs.position()[cluster_index].y() = input_rechits_soa[max_energy_index].dim2();
         }
-        outputs[cluster_index].z() = input_rechits_soa[max_energy_index].dim3();
+        outputs.position()[cluster_index].z() = input_rechits_soa[max_energy_index].dim3();
+        outputs.position()[cluster_index].layer() = input_rechits_soa[max_energy_index].layer();
       }  // uniform_elements
-    }  // operator()
+    }    // operator()
   };
 
   void HGCalLayerClustersSoAAlgoWrapper::run(Queue& queue,
@@ -149,16 +152,16 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                              float positionDeltaRho2,
                                              const HGCalSoARecHitsDeviceCollection::ConstView input_rechits_soa,
                                              const HGCalSoARecHitsExtraDeviceCollection::ConstView input_clusters_soa,
-                                             HGCalSoAClustersDeviceCollection::View outputs,
+                                             reco::CaloClusterDeviceCollection::View outputs,
                                              HGCalSoAClustersExtraDeviceCollection::View outputs_service) const {
-    auto x = cms::alpakatools::make_device_view<float>(queue, outputs.x(), size);
+    auto x = cms::alpakatools::make_device_view<float>(queue, outputs.position().x());
     alpaka::memset(queue, x, 0x0);
-    auto y = cms::alpakatools::make_device_view<float>(queue, outputs.y(), size);
+    auto y = cms::alpakatools::make_device_view<float>(queue, outputs.position().y());
     alpaka::memset(queue, y, 0x0);
-    auto energy = cms::alpakatools::make_device_view<float>(queue, outputs.energy(), size);
-    alpaka::memset(queue, energy, 0x0);
-    auto cells = cms::alpakatools::make_device_view<int>(queue, outputs.cells(), size);
+    auto cells = cms::alpakatools::make_device_view<int>(queue, outputs.position().cells());
     alpaka::memset(queue, cells, 0x0);
+    auto energy = cms::alpakatools::make_device_view<float>(queue, outputs.energy().energy());
+    alpaka::memset(queue, energy, 0x0);
     auto total_weight = cms::alpakatools::make_device_view<float>(queue, outputs_service.total_weight(), size);
     alpaka::memset(queue, total_weight, 0x0);
     auto total_weight_log = cms::alpakatools::make_device_view<float>(queue, outputs_service.total_weight_log(), size);

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersSoAAlgoWrapper.dev.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersSoAAlgoWrapper.dev.cc
@@ -3,8 +3,6 @@
 #include "HGCalLayerClustersSoAAlgoWrapper.h"
 #include "ConstantsForClusters.h"
 
-#include "CLUEAlgoAlpaka.h"
-
 #include <cstdint>
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersSoAAlgoWrapper.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalLayerClustersSoAAlgoWrapper.h
@@ -6,7 +6,8 @@
 #include "DataFormats/HGCalReco/interface/HGCalSoARecHitsHostCollection.h"
 #include "DataFormats/HGCalReco/interface/alpaka/HGCalSoARecHitsDeviceCollection.h"
 #include "DataFormats/HGCalReco/interface/alpaka/HGCalSoARecHitsExtraDeviceCollection.h"
-#include "DataFormats/HGCalReco/interface/alpaka/HGCalSoAClustersDeviceCollection.h"
+// #include "DataFormats/HGCalReco/interface/alpaka/HGCalSoAClustersDeviceCollection.h"
+#include "DataFormats/CaloRecHit/interface/alpaka/CaloClusterDeviceCollection.h"
 #include "RecoLocalCalo/HGCalRecProducers/interface/alpaka/HGCalSoAClustersExtraDeviceCollection.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
@@ -22,7 +23,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
              float positionDeltaRho2,
              const HGCalSoARecHitsDeviceCollection::ConstView input_rechits_soa,
              const HGCalSoARecHitsExtraDeviceCollection::ConstView input_clusters_soa,
-             HGCalSoAClustersDeviceCollection::View outputs,
+             reco::CaloClusterDeviceCollection::View outputs,
              HGCalSoAClustersExtraDeviceCollection::View outputs_service) const;
   };
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoALayerClustersProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoALayerClustersProducer.cc
@@ -2,6 +2,7 @@
 #include "DataFormats/HGCalReco/interface/HGCalSoARecHitsHostCollection.h"
 #include "DataFormats/HGCalReco/interface/alpaka/HGCalSoAClustersDeviceCollection.h"
 #include "DataFormats/HGCalReco/interface/alpaka/HGCalSoARecHitsExtraDeviceCollection.h"
+#include "DataFormats/CaloRecHit/interface/alpaka/CaloClusterDeviceCollection.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -58,7 +59,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       auto const& deviceInputClusters = iEvent.get(getTokenDeviceClusters_);
       auto const inputClusters_v = deviceInputClusters.view();
 
-      HGCalSoAClustersDeviceCollection output(iEvent.queue(), num_clusters_);
+      reco::CaloClusterDeviceCollection output(
+          iEvent.queue(), num_clusters_, num_clusters_, num_clusters_, num_clusters_);
       auto output_v = output.view();
       // Allocate workspace SoA cluster
       HGCalSoAClustersExtraDeviceCollection outputWorkspace(iEvent.queue(), num_clusters_);
@@ -87,7 +89,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   private:
     device::EDGetToken<HGCalSoARecHitsDeviceCollection> const getTokenDeviceRecHits_;
     device::EDGetToken<HGCalSoARecHitsExtraDeviceCollection> const getTokenDeviceClusters_;
-    device::EDPutToken<HGCalSoAClustersDeviceCollection> const deviceTokenSoAClusters_;
+    device::EDPutToken<reco::CaloClusterDeviceCollection> const deviceTokenSoAClusters_;
     HGCalLayerClustersSoAAlgoWrapper algo_;
     unsigned int num_clusters_;
     float thresholdW0_;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoALayerClustersProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoALayerClustersProducer.cc
@@ -61,6 +61,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       reco::CaloClusterDeviceCollection output(
           iEvent.queue(), num_clusters_, num_clusters_, num_clusters_, num_clusters_);
+      // Zero-initialise the whole buffer: run() only writes a subset of the
+      // columns (position, energy, seedID), so this guarantees the remaining
+      // columns (corrected energies, caloID/algoID/flags, timing) hold a
+      // defined value instead of uninitialised device memory.
+      output.zeroInitialise(iEvent.queue());
       auto output_v = output.view();
       // Allocate workspace SoA cluster
       HGCalSoAClustersExtraDeviceCollection outputWorkspace(iEvent.queue(), num_clusters_);

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoARecHitsLayerClustersProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoARecHitsLayerClustersProducer.cc
@@ -15,6 +15,9 @@
 
 #include "HGCalLayerClustersAlgoWrapper.h"
 
+#include <cstdint>
+#include <vector>
+
 // Processes the input RecHit SoA collection and generates an output SoA
 // containing all the necessary information to build the clusters.
 // Specifically, this producer does not create the clusters in any format.
@@ -31,6 +34,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     HGCalSoARecHitsLayerClustersProducer(edm::ParameterSet const& config)
         : EDProducer(config),
           getTokenDevice_{consumes(config.getParameter<edm::InputTag>("hgcalRecHitsSoA"))},
+          getTokenLayerSizes_{consumes<std::vector<uint32_t>>(
+              edm::InputTag(config.getParameter<edm::InputTag>("hgcalRecHitsSoA").label(), "layerSizes"))},
           deviceToken_{produces()},
           deltac_((float)config.getParameter<double>("deltac")),
           kappa_((float)config.getParameter<double>("kappa")),
@@ -42,12 +47,23 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       auto const& deviceInput = iEvent.get(getTokenDevice_);
       //std::cout << "Size of device collection: " << deviceInput->metadata().size() << std::endl;
       auto const input_v = deviceInput.view();
+      auto const& layerSizes = iEvent.get(getTokenLayerSizes_);
       // Allocate output SoA
       HGCalSoARecHitsExtraDeviceCollection output(iEvent.queue(), deviceInput->metadata().size());
+      // run() only fills the cluster index and the seed flag: zero-initialise the
+      // whole buffer so that the remaining columns hold a defined value instead
+      // of uninitialised device memory.
+      output.zeroInitialise(iEvent.queue());
       auto output_v = output.view();
 
-      algo_.run(
-          iEvent.queue(), deviceInput->metadata().size(), deltac_, kappa_, outlierDeltaFactor_, input_v, output_v);
+      algo_.run(iEvent.queue(),
+                deviceInput->metadata().size(),
+                deltac_,
+                kappa_,
+                outlierDeltaFactor_,
+                layerSizes,
+                input_v,
+                output_v);
       iEvent.emplace(deviceToken_, std::move(output));
     }
 
@@ -63,6 +79,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   private:
     // use device::EDGetToken<T> to read from device memory space
     device::EDGetToken<HGCalSoARecHitsDeviceCollection> const getTokenDevice_;
+    edm::EDGetTokenT<std::vector<uint32_t>> const getTokenLayerSizes_;
     device::EDPutToken<HGCalSoARecHitsExtraDeviceCollection> const deviceToken_;
     HGCalLayerClustersAlgoWrapper algo_;
     const float deltac_;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoARecHitsProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/alpaka/HGCalSoARecHitsProducer.cc
@@ -13,6 +13,10 @@
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
+#include <cassert>
+#include <cstdint>
+#include <vector>
+
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class HGCalSoARecHitsProducer : public stream::EDProducer<> {
@@ -31,7 +35,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           thicknessCorrection_(config.getParameter<std::vector<double>>("thicknessCorrection")),
           caloGeomToken_(consumesCollector().esConsumes<CaloGeometry, CaloGeometryRecord>()),
           hits_token_(consumes<HGCRecHitCollection>(config.getParameter<edm::InputTag>("recHits"))),
-          deviceToken_{produces()} {}
+          deviceToken_{produces()},
+          layerSizesToken_{produces("layerSizes")} {}
 
     ~HGCalSoARecHitsProducer() override = default;
 
@@ -46,41 +51,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       auto const& hits = *(hits_h.product());
       computeThreshold();
 
+      const unsigned int numberOfLayers = 2 * maxlayer_;
+
       // Count effective hits above threshold
-      uint32_t index = 0;
-      for (unsigned int i = 0; i < hits.size(); ++i) {
-        const HGCRecHit& hgrh = hits[i];
-        DetId detid = hgrh.detid();
-        unsigned int layerOnSide = (rhtools_.getLayerWithOffset(detid) - 1);
+      auto acceptHit = [&](const HGCRecHit& hgrh, int& layer, float& sigmaNoise) {
+        const DetId detid = hgrh.detid();
+        const unsigned int layerOnSide = (rhtools_.getLayerWithOffset(detid) - 1);
 
-        // set sigmaNoise default value 1 to use kappa value directly in case of
-        // sensor-independent thresholds
-        int thickness_index = rhtools_.getSiThickIndex(detid);
-        if (thickness_index == -1) {
-          thickness_index = maxNumberOfThickIndices_;
-        }
-        double storedThreshold = thresholds_[layerOnSide][thickness_index];
-        if (hgrh.energy() < storedThreshold)
-          continue;  // this sets the ZS threshold at ecut times the sigma noise
-        index++;
-      }
-
-      // Allocate Host SoA will contain one entry for each RecHit above threshold
-      HGCalSoARecHitsHostCollection cells(iEvent.queue(), index);
-      auto cellsView = cells.view();
-
-      // loop over all hits and create the Hexel structure, skip energies below ecut
-      // for each layer and wafer calculate the thresholds (sigmaNoise and energy)
-      // once
-      index = 0;
-      for (unsigned int i = 0; i < hits.size(); ++i) {
-        const HGCRecHit& hgrh = hits[i];
-        DetId detid = hgrh.detid();
-        unsigned int layerOnSide = (rhtools_.getLayerWithOffset(detid) - 1);
-
-        // set sigmaNoise default value 1 to use kappa value directly in case of
-        // sensor-independent thresholds
-        float sigmaNoise = 1.f;
         int thickness_index = rhtools_.getSiThickIndex(detid);
         if (thickness_index == -1) {
           thickness_index = maxNumberOfThickIndices_;
@@ -89,16 +66,58 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         if (detid.det() == DetId::HGCalHSi || detid.subdetId() == HGCHEF) {
           storedThreshold = thresholds_.at(layerOnSide).at(thickness_index + deltasi_index_regemfac_);
         }
-        sigmaNoise = v_sigmaNoise_.at(layerOnSide).at(thickness_index);
-
         if (hgrh.energy() < storedThreshold)
-          continue;  // this sets the ZS threshold at ecut times the sigma noise
-        // for the sensor
+          return false;
+
+        sigmaNoise = v_sigmaNoise_.at(layerOnSide).at(thickness_index);
+        const int offset = ((rhtools_.zside(detid) + 1) >> 1) * maxlayer_;
+        layer = layerOnSide + offset;
+        return true;
+      };
+
+      // Count hits above threshold, per layer
+      std::vector<uint32_t> hitsPerLayer(numberOfLayers, 0);
+      uint32_t index = 0;
+      for (unsigned int i = 0; i < hits.size(); ++i) {
+        int layer = 0;
+        float sigmaNoise = 1.f;
+        if (not acceptHit(hits[i], layer, sigmaNoise))
+          continue;
+        hitsPerLayer[layer]++;
+        index++;
+      }
+
+      // Hits are written grouped by layer, in increasing layer order, and keep
+      // their relative order within a layer.
+      std::vector<uint32_t> layerCursor(numberOfLayers, 0);
+      std::vector<uint32_t> layerSizes;
+      layerSizes.reserve(numberOfLayers);
+      uint32_t nextLayerStart = 0;
+      for (unsigned int layer = 0; layer < numberOfLayers; ++layer) {
+        layerCursor[layer] = nextLayerStart;
+        nextLayerStart += hitsPerLayer[layer];
+        if (hitsPerLayer[layer] > 0) {
+          layerSizes.push_back(hitsPerLayer[layer]);
+        }
+      }
+      assert(nextLayerStart == index);
+
+      // Allocate Host SoA will contain one entry for each RecHit above threshold
+      HGCalSoARecHitsHostCollection cells(iEvent.queue(), index);
+      auto cellsView = cells.view();
+
+      // loop over all hits and create the Hexel structure, skip energies below ecut
+      // for each layer and wafer calculate the thresholds (sigmaNoise and energy)
+      for (unsigned int i = 0; i < hits.size(); ++i) {
+        const HGCRecHit& hgrh = hits[i];
+        DetId detid = hgrh.detid();
+        int layer = 0;
+        float sigmaNoise = 1.f;
+        if (not acceptHit(hgrh, layer, sigmaNoise))
+          continue;
 
         const GlobalPoint position(rhtools_.getPosition(detid));
-        int offset = ((rhtools_.zside(detid) + 1) >> 1) * maxlayer_;
-        int layer = layerOnSide + offset;
-        auto entryInSoA = cellsView[index];
+        auto entryInSoA = cellsView[layerCursor[layer]++];
         if (detector_ == "BH") {
           entryInSoA.dim1() = position.eta();
           entryInSoA.dim2() = position.phi();
@@ -116,12 +135,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         entryInSoA.detid() = detid.rawId();
         entryInSoA.time() = hgrh.time();
         entryInSoA.timeError() = hgrh.timeError();
-        index++;
       }
 #if 0
         std::cout << "Size: " << cells->metadata().size() << " count cells: " << index
           << " i.e. " << cells->metadata().size() << std::endl;
 #endif
+
+      iEvent.emplace(layerSizesToken_, std::move(layerSizes));
 
       if constexpr (!std::is_same_v<Device, alpaka_common::DevHost>) {
         // Trigger copy async to GPU
@@ -170,6 +190,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
     edm::EDGetTokenT<HGCRecHitCollection> hits_token_;
     device::EDPutToken<HGCalSoARecHitsDeviceCollection> const deviceToken_;
+    edm::EDPutTokenT<std::vector<uint32_t>> const layerSizesToken_;
 
     void computeThreshold() {
       // To support the TDR geometry and also the post-TDR one (v9 onwards), we


### PR DESCRIPTION
step2.py with alpaka crashing with this:

``` bash

  ----- Begin Fatal Exception 14-Jul-2026 20:41:22 CEST-----------------------
  An exception of category 'DictionaryNotFound' occurred while
     [0] Constructing the EventProcessor
     [1] Constructing module: class=HGCalSoALayerClustersProducer@alpaka label='hltHgcalSoALayerClustersProducer'
     [2] Calling ProductRegistryHelper::addToRegistry, checking dictionaries for produced types
  Exception Message:
  No data dictionary found for the following classes:

    edm::DeviceProduct<PortableDeviceCollection<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>,reco::CaloClusterSoALayout<128,false>,void> >
    edm::Wrapper<edm::DeviceProduct<PortableDeviceCollection<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>,reco::CaloClusterSoALayout<128,false>,void> > >

  Most likely each dictionary was never generated, but it may
  be that it was generated in the wrong package. Please add
  (or move) the specification '<class name="whatever"/>' to
  the appropriate classes_def.xml file along with any other
  information needed there. For example, if this class has any
  transient members, you need to specify them in classes_def.xml.
  Also include the class header in classes.h

  A type listed above might or might not be the same as a
  type declared by a producer module with the function 'produces'.
  Instead it might be the type of a data member, base class,
  wrapped type, or other object needed by a produced type. Below
  is some additional information which lists the types declared
  to be produced by a producer module that are associated with
  the types whose dictionaries were not found:

    edm::DeviceProduct<PortableDeviceCollection<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>,reco::CaloClusterSoALayout<128,false>,void> >
```

Still crashing but just not this error message... 


Is this the best way to collaborate on one development branch? Do you suggest another way? 


